### PR TITLE
Add pytest and pytest-BDD tests

### DIFF
--- a/tests/bdd/test_user_stories.py
+++ b/tests/bdd/test_user_stories.py
@@ -1,0 +1,42 @@
+from pytest_bdd import scenarios, given, when, then
+from src.core.interpreter import DomainForgeInterpreter
+from src.core.models import DomainModel
+
+scenarios('user_stories.feature')
+
+@given('a DomainForge DSL file with the following content')
+def dsl_file_content():
+    return """
+    @Context {
+        #Entity {
+            name: String
+        }
+    }
+    """
+
+@when('the DSL file is interpreted')
+def interpret_dsl_file(dsl_file_content):
+    interpreter = DomainForgeInterpreter()
+    return interpreter.interpret(dsl_file_content)
+
+@then('the resulting domain model should have a context named "Context"')
+def check_context_name(interpret_dsl_file):
+    model = interpret_dsl_file
+    assert isinstance(model, DomainModel)
+    assert len(model.bounded_contexts) == 1
+    assert model.bounded_contexts[0].name == "Context"
+
+@then('the context should have an entity named "Entity"')
+def check_entity_name(interpret_dsl_file):
+    model = interpret_dsl_file
+    context = model.bounded_contexts[0]
+    assert len(context.entities) == 1
+    assert context.entities[0].name == "Entity"
+
+@then('the entity should have a property named "name" of type "String"')
+def check_entity_property(interpret_dsl_file):
+    model = interpret_dsl_file
+    entity = model.bounded_contexts[0].entities[0]
+    assert len(entity.properties) == 1
+    assert entity.properties[0].name == "name"
+    assert entity.properties[0].type == "String"

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,51 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.infrastructure.app import app
+from src.infrastructure.database import get_session, init_database
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+from src.config.settings import get_settings
+
+# Create a test client
+client = TestClient(app)
+
+# Create a test database engine
+settings = get_settings()
+test_engine = create_async_engine(settings.DATABASE_URL, echo=True)
+TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine, class_=AsyncSession)
+
+# Dependency override for getting a test session
+async def override_get_session():
+    async with TestSessionLocal() as session:
+        yield session
+
+app.dependency_overrides[get_session] = override_get_session
+
+@pytest.fixture(scope="module", autouse=True)
+async def setup_database():
+    # Initialize the test database
+    async with test_engine.begin() as conn:
+        await conn.run_sync(init_database)
+    yield
+    # Drop the test database tables after tests
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+def test_create_entity():
+    response = client.post("/api/entities", json={"name": "Test Entity"})
+    assert response.status_code == 201
+    assert response.json()["name"] == "Test Entity"
+
+def test_get_entity():
+    response = client.get("/api/entities/1")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Test Entity"
+
+def test_update_entity():
+    response = client.put("/api/entities/1", json={"name": "Updated Entity"})
+    assert response.status_code == 200
+    assert response.json()["name"] == "Updated Entity"
+
+def test_delete_entity():
+    response = client.delete("/api/entities/1")
+    assert response.status_code == 204

--- a/tests/unit/test_grammar.py
+++ b/tests/unit/test_grammar.py
@@ -1,0 +1,282 @@
+import pytest
+from lark import Lark, Tree, Token
+
+@pytest.fixture
+def parser():
+    grammar = """
+    %import common.WS
+    %import common.INT
+    %import common.FLOAT
+    %import common.WORD
+    %import common.ESCAPED_STRING
+    %ignore WS
+
+    // --------------------- Terminals ---------------------
+
+    // MODIFIERS: Modify relationships to indicate obligations or permissions.
+    MODIFIER: "!"    // Must (Obligation)
+            | "~"   // Should (Recommendation)
+            | "?"   // May (Permission)
+
+    // ENTITY SYMBOLS: Indicate the type of an entity.
+    ENTITY_SYMBOL: "#"    // Entity (aggregate root)
+                | "%"    // Value object
+                | "^"    // Event
+                | ">>"   // Service/Process
+                | "&"    // Role/Actor
+                | "@"    // Context/Bounded Context
+                | "$"    // Repository
+                | "*"    // Module/Package
+
+    // RELATIONSHIP SYMBOLS: Represent various relationship types.
+    RELATIONSHIP_SYMBOL: "=>"      // Dependency / Uses
+                    | "<->"      // Bidirectional Association
+                    | "--"       // Association
+                    | "->"       // One-way Association
+                    | "."        // Composition
+                    | "::"       // Inheritance
+                    | "/"        // Implementation
+                    | "="        // Equivalence
+
+    // API and UI annotations
+    HTTP_METHOD: "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
+    UI_COMPONENT: "Form" | "Table" | "Card" | "Detail" | "List"
+    VISIBILITY: "public" | "private" | "protected"
+
+    // Symbols used for grouping expressions
+    LPAREN: "("
+    RPAREN: ")"
+    LSQBRACKET: "["
+    RSQBRACKET: "]"
+    LCURLYBRACE: "{"
+    RCURLYBRACE: "}"
+    LANGELED: "<"
+    RANGELED: ">"
+
+    // Other separators
+    ITEM_SEPARATOR: ","           // Separator in groups and collections
+    COLON: ":"
+    EQUALS: "="
+
+    // Comments
+    COMMENT: /\/\/[^\n]*/         // Single-line comments
+        | /\/\*[\s\S]*?\*\//    // Multi-line comments
+    %ignore COMMENT
+
+    // IDENTIFIERS: Names for entities.
+    IDENTIFIER: /[a-zA-Z_][a-zA-Z0-9_]*/
+
+    // String literals
+    STRING: ESCAPED_STRING
+
+    // --------------------- Grammar Rules ---------------------
+
+    // A complete domain model consists of one or more bounded contexts
+    start: context_definition+
+
+    // A bounded context defines a subsystem boundary
+    context_definition: "@" IDENTIFIER LCURLYBRACE
+                        (entity_definition
+                        | value_object_definition
+                        | event_definition
+                        | service_definition
+                        | repository_definition
+                        | module_definition
+                        | role_definition)*
+                    RCURLYBRACE
+
+    // Entity - aggregate root
+    entity_definition: "#" IDENTIFIER (COLON IDENTIFIER)? LCURLYBRACE
+                        (property_definition
+                        | method_definition
+                        | api_definition
+                        | ui_definition)*
+                    RCURLYBRACE
+
+    // Value Object - immutable with no identity
+    value_object_definition: "%" IDENTIFIER LCURLYBRACE
+                            property_definition*
+                        RCURLYBRACE
+
+    // Event definition
+    event_definition: "^" IDENTIFIER LCURLYBRACE
+                    property_definition*
+                    RCURLYBRACE
+
+    // Service definition
+    service_definition: ">>" IDENTIFIER LCURLYBRACE
+                        (method_definition | api_definition)*
+                    RCURLYBRACE
+
+    // Repository definition
+    repository_definition: "$" IDENTIFIER LCURLYBRACE
+                        method_definition*
+                    RCURLYBRACE
+
+    // Module definition
+    module_definition: "*" IDENTIFIER LCURLYBRACE
+                        (entity_definition
+                        | value_object_definition
+                        | event_definition
+                        | service_definition
+                        | repository_definition)*
+                    RCURLYBRACE
+
+    // Role definition
+    role_definition: "&" IDENTIFIER LCURLYBRACE
+                    property_definition*
+                    RCURLYBRACE
+
+    // Property definition
+    property_definition: IDENTIFIER COLON type_definition (EQUALS default_value)?
+                        (LSQBRACKET constraint+ RSQBRACKET)?
+
+    // Type definition including collections
+    type_definition: IDENTIFIER              -> simple_type
+                | IDENTIFIER LANGLED IDENTIFIER RANGLED  -> generic_type
+                | "List" LANGLED type_definition RANGLED -> list_type
+                | "Dict" LANGLED type_definition COLON type_definition RANGLED -> dict_type
+
+    // Method definition
+    method_definition: (VISIBILITY)? IDENTIFIER LPAREN parameter_list? RPAREN (COLON type_definition)?
+                        (LCURLYBRACE description? RCURLYBRACE)?
+
+    // Parameter list
+    parameter_list: parameter (ITEM_SEPARATOR parameter)*
+
+    // Parameter
+    parameter: IDENTIFIER COLON type_definition (EQUALS default_value)?
+
+    // Default value
+    default_value: INT
+                | FLOAT
+                | STRING
+                | IDENTIFIER
+                | LSQBRACKET value_list? RSQBRACKET
+
+    // Value list
+    value_list: value (ITEM_SEPARATOR value)*
+
+    // Value
+    value: INT
+        | FLOAT
+        | STRING
+        | IDENTIFIER
+        | LSQBRACKET value_list? RSQBRACKET
+
+    // Constraint
+    constraint: "required"
+            | "unique"
+            | "min" COLON INT
+            | "max" COLON INT
+            | "pattern" COLON STRING
+            | "foreign_key" COLON IDENTIFIER
+
+    // Relationship definition
+    relationship_definition: source_entity RELATIONSHIP_SYMBOL target_entity (LCURLYBRACE description RCURLYBRACE)?
+
+    // Source and target entities
+    source_entity: IDENTIFIER
+    target_entity: IDENTIFIER
+
+    // Description
+    description: STRING
+
+    // API definition
+    api_definition: "api" COLON HTTP_METHOD STRING (LPAREN parameter_list? RPAREN)?
+                (COLON type_definition)? (LCURLYBRACE description? RCURLYBRACE)?
+
+    // UI definition
+    ui_definition: "ui" COLON UI_COMPONENT (LPAREN parameter_list? RPAREN)?
+                (LCURLYBRACE description? RCURLYBRACE)?
+    """
+    return Lark(grammar, start='start', parser='lalr')
+
+def test_parse_simple_entity(parser):
+    dsl = """
+    @Context {
+        #Entity {
+            name: String
+        }
+    }
+    """
+    tree = parser.parse(dsl)
+    assert isinstance(tree, Tree)
+    assert tree.data == "start"
+    assert len(tree.children) == 1
+    context = tree.children[0]
+    assert context.data == "context_definition"
+    assert len(context.children) == 2
+    assert context.children[0] == Token("IDENTIFIER", "Context")
+    entity = context.children[1].children[0]
+    assert entity.data == "entity_definition"
+    assert entity.children[0] == Token("IDENTIFIER", "Entity")
+    assert entity.children[1].data == "property_definition"
+    assert entity.children[1].children[0] == Token("IDENTIFIER", "name")
+    assert entity.children[1].children[1] == Token("IDENTIFIER", "String")
+
+def test_parse_relationship(parser):
+    dsl = """
+    @Context {
+        #Entity1 {
+            name: String
+        }
+        #Entity2 {
+            description: String
+        }
+        Entity1 -> Entity2
+    }
+    """
+    tree = parser.parse(dsl)
+    assert isinstance(tree, Tree)
+    assert tree.data == "start"
+    assert len(tree.children) == 1
+    context = tree.children[0]
+    assert context.data == "context_definition"
+    assert len(context.children) == 4
+    assert context.children[0] == Token("IDENTIFIER", "Context")
+    entity1 = context.children[1].children[0]
+    assert entity1.data == "entity_definition"
+    assert entity1.children[0] == Token("IDENTIFIER", "Entity1")
+    assert entity1.children[1].data == "property_definition"
+    assert entity1.children[1].children[0] == Token("IDENTIFIER", "name")
+    assert entity1.children[1].children[1] == Token("IDENTIFIER", "String")
+    entity2 = context.children[2].children[0]
+    assert entity2.data == "entity_definition"
+    assert entity2.children[0] == Token("IDENTIFIER", "Entity2")
+    assert entity2.children[1].data == "property_definition"
+    assert entity2.children[1].children[0] == Token("IDENTIFIER", "description")
+    assert entity2.children[1].children[1] == Token("IDENTIFIER", "String")
+    relationship = context.children[3]
+    assert relationship.data == "relationship_definition"
+    assert relationship.children[0] == Token("IDENTIFIER", "Entity1")
+    assert relationship.children[1] == Token("RELATIONSHIP_SYMBOL", "->")
+    assert relationship.children[2] == Token("IDENTIFIER", "Entity2")
+
+def test_parse_service_with_method(parser):
+    dsl = """
+    @Context {
+        >>Service {
+            doSomething(param: String): Void
+        }
+    }
+    """
+    tree = parser.parse(dsl)
+    assert isinstance(tree, Tree)
+    assert tree.data == "start"
+    assert len(tree.children) == 1
+    context = tree.children[0]
+    assert context.data == "context_definition"
+    assert len(context.children) == 2
+    assert context.children[0] == Token("IDENTIFIER", "Context")
+    service = context.children[1].children[0]
+    assert service.data == "service_definition"
+    assert service.children[0] == Token("IDENTIFIER", "Service")
+    method = service.children[1]
+    assert method.data == "method_definition"
+    assert method.children[0] == Token("IDENTIFIER", "doSomething")
+    assert method.children[1].data == "parameter_list"
+    assert method.children[1].children[0].data == "parameter"
+    assert method.children[1].children[0].children[0] == Token("IDENTIFIER", "param")
+    assert method.children[1].children[0].children[1] == Token("IDENTIFIER", "String")
+    assert method.children[2] == Token("IDENTIFIER", "Void")

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -1,0 +1,122 @@
+import pytest
+from src.core.interpreter import DomainForgeInterpreter
+from src.core.models import DomainModel
+
+@pytest.fixture
+def interpreter():
+    return DomainForgeInterpreter()
+
+def test_interpret_simple_entity(interpreter):
+    dsl = """
+    @Context {
+        #Entity {
+            name: String
+        }
+    }
+    """
+    model = interpreter.interpret(dsl)
+    assert isinstance(model, DomainModel)
+    assert len(model.bounded_contexts) == 1
+    context = model.bounded_contexts[0]
+    assert context.name == "Context"
+    assert len(context.entities) == 1
+    entity = context.entities[0]
+    assert entity.name == "Entity"
+    assert len(entity.properties) == 1
+    prop = entity.properties[0]
+    assert prop.name == "name"
+    assert prop.type == "String"
+
+def test_interpret_relationship(interpreter):
+    dsl = """
+    @Context {
+        #Entity1 {
+            name: String
+        }
+        #Entity2 {
+            description: String
+        }
+        Entity1 -> Entity2
+    }
+    """
+    model = interpreter.interpret(dsl)
+    assert isinstance(model, DomainModel)
+    assert len(model.bounded_contexts) == 1
+    context = model.bounded_contexts[0]
+    assert context.name == "Context"
+    assert len(context.entities) == 2
+    entity1 = context.entities[0]
+    entity2 = context.entities[1]
+    assert entity1.name == "Entity1"
+    assert entity2.name == "Entity2"
+    assert len(entity1.relationships) == 1
+    relationship = entity1.relationships[0]
+    assert relationship.source_entity == "Entity1"
+    assert relationship.target_entity == "Entity2"
+    assert relationship.relationship_type == "->"
+
+def test_interpret_service_with_method(interpreter):
+    dsl = """
+    @Context {
+        >>Service {
+            doSomething(param: String): Void
+        }
+    }
+    """
+    model = interpreter.interpret(dsl)
+    assert isinstance(model, DomainModel)
+    assert len(model.bounded_contexts) == 1
+    context = model.bounded_contexts[0]
+    assert context.name == "Context"
+    assert len(context.services) == 1
+    service = context.services[0]
+    assert service.name == "Service"
+    assert len(service.methods) == 1
+    method = service.methods[0]
+    assert method.name == "doSomething"
+    assert len(method.parameters) == 1
+    param = method.parameters[0]
+    assert param.name == "param"
+    assert param.type == "String"
+    assert method.return_type == "Void"
+
+def test_interpret_file(interpreter, tmp_path):
+    dsl = """
+    @Context {
+        #Entity {
+            name: String
+        }
+    }
+    """
+    file_path = tmp_path / "test.domainforge"
+    file_path.write_text(dsl)
+    model = interpreter.interpret_file(file_path)
+    assert isinstance(model, DomainModel)
+    assert len(model.bounded_contexts) == 1
+    context = model.bounded_contexts[0]
+    assert context.name == "Context"
+    assert len(context.entities) == 1
+    entity = context.entities[0]
+    assert entity.name == "Entity"
+    assert len(entity.properties) == 1
+    prop = entity.properties[0]
+    assert prop.name == "name"
+    assert prop.type == "String"
+
+def test_export_model(interpreter, tmp_path):
+    dsl = """
+    @Context {
+        #Entity {
+            name: String
+        }
+    }
+    """
+    model = interpreter.interpret(dsl)
+    output_path = tmp_path / "domain_model.json"
+    interpreter.export_model(model, output_path)
+    assert output_path.exists()
+    exported_data = output_path.read_text()
+    assert '"name": "Context"' in exported_data
+    assert '"name": "Entity"' in exported_data
+    assert '"name": "name"' in exported_data
+    assert '"type": "String"' in exported_data

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,0 +1,96 @@
+import pytest
+from lark import Tree, Token
+from src.core.parser import DomainForgeParser
+
+@pytest.fixture
+def parser():
+    return DomainForgeParser()
+
+def test_parse_simple_entity(parser):
+    dsl = """
+    @Context {
+        #Entity {
+            name: String
+        }
+    }
+    """
+    tree = parser.parse(dsl)
+    assert isinstance(tree, Tree)
+    assert tree.data == "start"
+    assert len(tree.children) == 1
+    context = tree.children[0]
+    assert context.data == "context_definition"
+    assert len(context.children) == 2
+    assert context.children[0] == Token("IDENTIFIER", "Context")
+    entity = context.children[1].children[0]
+    assert entity.data == "entity_definition"
+    assert entity.children[0] == Token("IDENTIFIER", "Entity")
+    assert entity.children[1].data == "property_definition"
+    assert entity.children[1].children[0] == Token("IDENTIFIER", "name")
+    assert entity.children[1].children[1] == Token("IDENTIFIER", "String")
+
+def test_parse_relationship(parser):
+    dsl = """
+    @Context {
+        #Entity1 {
+            name: String
+        }
+        #Entity2 {
+            description: String
+        }
+        Entity1 -> Entity2
+    }
+    """
+    tree = parser.parse(dsl)
+    assert isinstance(tree, Tree)
+    assert tree.data == "start"
+    assert len(tree.children) == 1
+    context = tree.children[0]
+    assert context.data == "context_definition"
+    assert len(context.children) == 4
+    assert context.children[0] == Token("IDENTIFIER", "Context")
+    entity1 = context.children[1].children[0]
+    assert entity1.data == "entity_definition"
+    assert entity1.children[0] == Token("IDENTIFIER", "Entity1")
+    assert entity1.children[1].data == "property_definition"
+    assert entity1.children[1].children[0] == Token("IDENTIFIER", "name")
+    assert entity1.children[1].children[1] == Token("IDENTIFIER", "String")
+    entity2 = context.children[2].children[0]
+    assert entity2.data == "entity_definition"
+    assert entity2.children[0] == Token("IDENTIFIER", "Entity2")
+    assert entity2.children[1].data == "property_definition"
+    assert entity2.children[1].children[0] == Token("IDENTIFIER", "description")
+    assert entity2.children[1].children[1] == Token("IDENTIFIER", "String")
+    relationship = context.children[3]
+    assert relationship.data == "relationship_definition"
+    assert relationship.children[0] == Token("IDENTIFIER", "Entity1")
+    assert relationship.children[1] == Token("RELATIONSHIP_SYMBOL", "->")
+    assert relationship.children[2] == Token("IDENTIFIER", "Entity2")
+
+def test_parse_service_with_method(parser):
+    dsl = """
+    @Context {
+        >>Service {
+            doSomething(param: String): Void
+        }
+    }
+    """
+    tree = parser.parse(dsl)
+    assert isinstance(tree, Tree)
+    assert tree.data == "start"
+    assert len(tree.children) == 1
+    context = tree.children[0]
+    assert context.data == "context_definition"
+    assert len(context.children) == 2
+    assert context.children[0] == Token("IDENTIFIER", "Context")
+    service = context.children[1].children[0]
+    assert service.data == "service_definition"
+    assert service.children[0] == Token("IDENTIFIER", "Service")
+    method = service.children[1]
+    assert method.data == "method_definition"
+    assert method.children[0] == Token("IDENTIFIER", "doSomething")
+    assert method.children[1].data == "parameter_list"
+    assert method.children[1].children[0].data == "parameter"
+    assert method.children[1].children[0].children[0] == Token("IDENTIFIER", "param")
+    assert method.children[1].children[0].children[1] == Token("IDENTIFIER", "String")
+    assert method.children[2] == Token("IDENTIFIER", "Void")

--- a/tests/unit/test_transformer.py
+++ b/tests/unit/test_transformer.py
@@ -1,0 +1,127 @@
+import pytest
+from lark import Tree, Token
+from src.core.transformer import DomainForgeTransformer
+from src.core.models import (
+    DomainModel,
+    BoundedContext,
+    Entity,
+    ValueObject,
+    Event,
+    Service,
+    Repository,
+    Role,
+    Module,
+    Property,
+    Method,
+    ApiEndpoint,
+    UiComponent,
+    Relationship,
+    Parameter,
+)
+
+@pytest.fixture
+def transformer():
+    return DomainForgeTransformer()
+
+def test_transform_simple_entity(transformer):
+    tree = Tree("start", [
+        Tree("context_definition", [
+            Token("IDENTIFIER", "Context"),
+            Tree("entity_definition", [
+                Token("IDENTIFIER", "Entity"),
+                Tree("property_definition", [
+                    Token("IDENTIFIER", "name"),
+                    Token("IDENTIFIER", "String")
+                ])
+            ])
+        ])
+    ])
+    model = transformer.transform(tree)
+    assert isinstance(model, DomainModel)
+    assert len(model.bounded_contexts) == 1
+    context = model.bounded_contexts[0]
+    assert context.name == "Context"
+    assert len(context.entities) == 1
+    entity = context.entities[0]
+    assert entity.name == "Entity"
+    assert len(entity.properties) == 1
+    prop = entity.properties[0]
+    assert prop.name == "name"
+    assert prop.type == "String"
+
+def test_transform_relationship(transformer):
+    tree = Tree("start", [
+        Tree("context_definition", [
+            Token("IDENTIFIER", "Context"),
+            Tree("entity_definition", [
+                Token("IDENTIFIER", "Entity1"),
+                Tree("property_definition", [
+                    Token("IDENTIFIER", "name"),
+                    Token("IDENTIFIER", "String")
+                ])
+            ]),
+            Tree("entity_definition", [
+                Token("IDENTIFIER", "Entity2"),
+                Tree("property_definition", [
+                    Token("IDENTIFIER", "description"),
+                    Token("IDENTIFIER", "String")
+                ])
+            ]),
+            Tree("relationship_definition", [
+                Token("IDENTIFIER", "Entity1"),
+                Token("RELATIONSHIP_SYMBOL", "->"),
+                Token("IDENTIFIER", "Entity2")
+            ])
+        ])
+    ])
+    model = transformer.transform(tree)
+    assert isinstance(model, DomainModel)
+    assert len(model.bounded_contexts) == 1
+    context = model.bounded_contexts[0]
+    assert context.name == "Context"
+    assert len(context.entities) == 2
+    entity1 = context.entities[0]
+    entity2 = context.entities[1]
+    assert entity1.name == "Entity1"
+    assert entity2.name == "Entity2"
+    assert len(entity1.relationships) == 1
+    relationship = entity1.relationships[0]
+    assert relationship.source_entity == "Entity1"
+    assert relationship.target_entity == "Entity2"
+    assert relationship.relationship_type == "->"
+
+def test_transform_service_with_method(transformer):
+    tree = Tree("start", [
+        Tree("context_definition", [
+            Token("IDENTIFIER", "Context"),
+            Tree("service_definition", [
+                Token("IDENTIFIER", "Service"),
+                Tree("method_definition", [
+                    Token("IDENTIFIER", "doSomething"),
+                    Tree("parameter_list", [
+                        Tree("parameter", [
+                            Token("IDENTIFIER", "param"),
+                            Token("IDENTIFIER", "String")
+                        ])
+                    ]),
+                    Token("IDENTIFIER", "Void")
+                ])
+            ])
+        ])
+    ])
+    model = transformer.transform(tree)
+    assert isinstance(model, DomainModel)
+    assert len(model.bounded_contexts) == 1
+    context = model.bounded_contexts[0]
+    assert context.name == "Context"
+    assert len(context.services) == 1
+    service = context.services[0]
+    assert service.name == "Service"
+    assert len(service.methods) == 1
+    method = service.methods[0]
+    assert method.name == "doSomething"
+    assert len(method.parameters) == 1
+    param = method.parameters[0]
+    assert param.name == "param"
+    assert param.type == "String"
+    assert method.return_type == "Void"


### PR DESCRIPTION
Add a comprehensive suite of pytest and pytest-BDD tests for the project.

* **Unit Tests**
  - Add `tests/unit/test_parser.py` with unit tests for `DomainForgeParser` class.
  - Add `tests/unit/test_transformer.py` with unit tests for `DomainForgeTransformer` class.
  - Add `tests/unit/test_interpreter.py` with unit tests for `DomainForgeInterpreter` class.
  - Add `tests/unit/test_grammar.py` with unit tests for `grammar.lark` file.

* **Integration Tests**
  - Add `tests/integration/test_api.py` with integration tests for API endpoints using FastAPI's TestClient.

* **BDD Tests**
  - Add `tests/bdd/test_user_stories.py` with BDD tests for user stories using `pytest-bdd`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SPRIME01/domain-forge/pull/1?shareId=450950bb-8027-4784-8742-61cf96e4e10f).

## Summary by Sourcery

Adds pytest and pytest-bdd tests to the project, covering unit, integration, and BDD testing.

Tests:
- Adds unit tests for the parser, transformer, interpreter, and grammar components.
- Adds integration tests for API endpoints using FastAPI's TestClient.
- Adds BDD tests for user stories using pytest-bdd.